### PR TITLE
Replace jQuery .delegate() with .on()

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     }
   ],
   "dependencies": {
-    "jquery": ">=1.6.0",
+    "jquery": ">=1.7.0",
     "imagesloaded": ">=3.0.0"
   },
   "devDependencies": {

--- a/src/core/content.js
+++ b/src/core/content.js
@@ -86,10 +86,10 @@ PROTOTYPE._createTitle = function()
 	.insertBefore(elements.content)
 
 	// Button-specific events
-	.delegate('.qtip-close', 'mousedown keydown mouseup keyup mouseout', function(event) {
+	.on('mousedown keydown mouseup keyup mouseout', '.qtip-close', function(event) {
 		$(this).toggleClass('ui-state-active ui-state-focus', event.type.substr(-4) === 'down');
 	})
-	.delegate('.qtip-close', 'mouseover mouseout', function(event){
+	.on('mouseover mouseout', '.qtip-close', function(event){
 		$(this).toggleClass('ui-state-hover', event.type === 'mouseover');
 	});
 

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -99,8 +99,9 @@ PROTOTYPE._unbind = function(targets, suffix) {
 
 // Global delegation helper
 function delegate(selector, events, method) {
-	$(document.body).delegate(selector,
+	$(document.body).on(
 		(events.split ? events : events.join('.'+NAMESPACE + ' ')) + '.'+NAMESPACE,
+		selector,
 		function() {
 			var api = QTIP.api[ $.attr(this, ATTR_ID) ];
 			api && !api.disabled && method.apply(api, arguments);


### PR DESCRIPTION
jQuery has discouraged the use of .delegate()
in favor of .on() since the release of jQuery 1.7 in 2011.
In jQuery 3, .delegate() has been deprecated and
is up for removal. So jquery-migrate complains
about the usage of .delegate().

This change will replace delegate() with on(). That
also means jQuery versions < 1.7 will not be
supported, but supposedly it should be more
important to support the current version of jQuery
than to support the 6 year old version.
(At least in future releases?)